### PR TITLE
Fix error message if PUBLISH_WEBSITE is not found

### DIFF
--- a/bin/compile.ps1
+++ b/bin/compile.ps1
@@ -83,7 +83,8 @@ if ($solutionFiles -ne $null)
         }
         else
         {
-            if(!(Test-Path ($publishedFolder | Where-Object -Property Name -EQ $env:PUBLISH_WEBSITE)))
+            $publishWebsitePath = $publishedFolder | Where-Object -Property Name -EQ $env:PUBLISH_WEBSITE            
+            if($publishWebsitePath -eq $null)
             {
                 Write-Output "$env:PUBLISH_WEBSITE not found"
                 [Console]::Out.Flush()


### PR DESCRIPTION
If the directory PUBLISH_WEBSITE does not exist, this would result in a "Test-Path $null" call, which would lead to a confusing error message on staging failure.
We don't need to Test-Path since the $publishFolder is obtained by reading the "_PublishedWebsites" directory. 
A null check should be enough.